### PR TITLE
Dashboard status and API test

### DIFF
--- a/dashboard/static/dashboard.js
+++ b/dashboard/static/dashboard.js
@@ -177,7 +177,7 @@ function updateGlobalStatus(data) {
             ${activeCount} Scraper${activeCount > 1 ? 's' : ''} Running
         `;
     } else {
-        globalStatusEl.className = 'global-status';
+        globalStatusEl.className = 'global-status inactive';
         globalStatusEl.innerHTML = 'All Scrapers Idle';
     }
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,7 +99,7 @@ class TestAPIEndpoints:
         """Test that invalid YAML syntax returns 400"""
         invalid_yaml = "retailers:\n  verizon:\n    - invalid syntax ["
         response = client.post('/api/config',
-                              json={'config': invalid_yaml},
+                              json={'content': invalid_yaml},
                               content_type='application/json')
         assert response.status_code == 400
         data = response.get_json()


### PR DESCRIPTION
Fix global status styling for idle state and correct JSON key in config API test.

The global status indicator for "All Scrapers Idle" was incorrectly displaying with an active (green) background due to a missing `inactive` CSS class. The test `test_api_config_post_invalid_yaml_returns_400` was also failing for the wrong reason, as it used the incorrect JSON key (`config` instead of `content`) when calling the `/api/config` endpoint, preventing actual YAML validation from being tested.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Dashboard UI:** When no scrapers are active, `updateGlobalStatus` now applies `global-status inactive` to show the correct idle styling (`dashboard/static/dashboard.js`).
> - **API tests:** `test_api_config_post_invalid_yaml_returns_400` posts YAML under `content` instead of `config` to match the `/api/config` contract (`tests/test_api.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa9a66cd3584b54bf906147c42e9d139a1d1f989. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->