### PR TITLE
docs: add UI state preservation fix write-up for dashboard auto-refresh

### DIFF
--- a/UI_STATE_FIX.md
+++ b/UI_STATE_FIX.md
@@ -1,0 +1,153 @@
+# UI State Preservation Fix - Dashboard Auto-Refresh
+
+## Issue Summary
+
+The dashboard's auto-refresh functionality was causing a poor user experience by destroying UI state every 5 seconds.
+
+## The Problem
+
+### Symptom
+Users who opened a run history panel would see it unexpectedly close after 5 seconds, losing all loaded data and requiring them to re-open and wait for the data to reload.
+
+### Root Cause
+The `updateRetailers()` function in `dashboard/static/dashboard.js` was replacing the entire retailer grid HTML using `container.innerHTML = html`, which:
+1. Destroyed all existing DOM elements and their associated state
+2. Created fresh DOM elements without the `open` class
+3. Lost all loaded run history data
+4. Reset button text back to "View Run History"
+
+### Code Location
+- **File**: `dashboard/static/dashboard.js`
+- **Function**: `updateRetailers()` (lines 194-238)
+- **Trigger**: Auto-refresh runs every 5 seconds via `updateDashboard()`
+
+## The Solution
+
+### Implementation Strategy
+Implemented a state preservation pattern:
+
+#### 1. **Capture State Before Update** (Lines 198-208)
+```javascript
+const uiState = {};
+for (const [retailerId] of Object.entries(RETAILER_CONFIG)) {
+    const panel = document.getElementById(`history-${retailerId}`);
+    if (panel) {
+        uiState[retailerId] = {
+            isOpen: panel.classList.contains('open'),
+            content: panel.querySelector('.run-history-list')?.innerHTML || ''
+        };
+    }
+}
+```
+
+For each retailer, captures:
+- Whether the run history panel is open (`'open'` class presence)
+- The loaded content from the run history list
+
+#### 2. **Perform DOM Update** (Lines 210-217)
+```javascript
+let html = '';
+for (const [retailerId, retailerData] of Object.entries(RETAILER_CONFIG)) {
+    const data = retailers[retailerId] || { status: 'pending' };
+    html += renderRetailerCard(retailerId, data);
+}
+
+container.innerHTML = html;
+```
+
+Updates the HTML as before, but now we have the state saved.
+
+#### 3. **Restore State After Update** (Lines 219-237)
+```javascript
+for (const [retailerId, state] of Object.entries(uiState)) {
+    if (state.isOpen) {
+        const panel = document.getElementById(`history-${retailerId}`);
+        const button = panel?.previousElementSibling;
+        const listContainer = document.getElementById(`history-list-${retailerId}`);
+        
+        if (panel && button && listContainer) {
+            panel.classList.add('open');
+            button.classList.add('active');
+            button.textContent = '📜 Hide Run History';
+            
+            // Restore the loaded content
+            if (state.content && !state.content.includes('Loading...')) {
+                listContainer.innerHTML = state.content;
+            }
+        }
+    }
+}
+```
+
+For panels that were open:
+- Re-applies the `'open'` class to the panel
+- Re-applies the `'active'` class to the toggle button
+- Updates button text to match the open state
+- Restores the loaded run history content (avoiding "Loading..." states)
+
+### Technical Details
+
+**Safe Property Access**: Uses optional chaining (`?.`) to prevent errors if elements don't exist during transition.
+
+**Smart Content Restoration**: Only restores content if:
+1. Content exists (not empty string)
+2. Content doesn't contain "Loading..." (avoids restoring temporary loading states)
+
+**State Isolation**: Each retailer's state is preserved independently, so opening multiple panels works correctly.
+
+## Benefits
+
+### User Experience Improvements
+1. ✅ **Persistent Panels**: Open panels stay open during auto-refresh
+2. ✅ **Data Preservation**: Loaded run history data persists across refreshes
+3. ✅ **Consistent UI**: Button states remain synchronized with panel states
+4. ✅ **No Interruption**: Users can browse run history without unexpected closures
+5. ✅ **Network Efficiency**: No need to reload data that's already displayed
+
+### Implementation Quality
+- Minimal code changes (added ~30 lines to existing function)
+- No breaking changes to existing functionality
+- Backward compatible (works even if no panels are open)
+- Defensive programming with safe property access
+- No additional API calls or dependencies
+
+## Testing Recommendations
+
+### Manual Testing Steps
+1. Open dashboard in browser
+2. Click "View Run History" for any retailer
+3. Observe the panel opens and loads data
+4. Wait for auto-refresh cycle (5 seconds)
+5. Verify:
+   - Panel remains open ✅
+   - Content is still visible ✅
+   - Button still shows "Hide Run History" ✅
+   - Can still interact with logs and other buttons ✅
+
+### Edge Cases Covered
+- Multiple panels open simultaneously
+- Panel with no loaded data (error states)
+- Panel in loading state during refresh
+- Rapid open/close before refresh
+- Missing DOM elements during transition
+
+## Related Improvements
+
+This fix could be extended to preserve other UI states:
+- Scroll positions within panels
+- Expanded/collapsed sections
+- Active button hover states
+- Form input values (if any are added)
+
+## Commit Details
+
+- **Commit**: `e1f8fa8`
+- **Branch**: `pr-8`
+- **Files Modified**: `dashboard/static/dashboard.js` (+33 lines)
+- **Status**: Pushed to remote ✅
+
+## See Also
+
+- Security fixes in commit `a412ea3` (path traversal vulnerability)
+- Security fixes in commit `e9d5736` (additional security hardening)
+- Original implementation in `dashboard/static/dashboard.js`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `UI_STATE_FIX.md` documenting the dashboard auto-refresh UI state loss and the implemented fix.
> 
> - Explains the root cause in `updateRetailers()` replacing DOM via `container.innerHTML`
> - Details the capture/restore pattern (save panel `open` state and content, reapply after refresh)
> - Provides technical notes (optional chaining, restore guards) and concise manual testing steps
> - Serves as reference for related future UI state preservation improvements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0341dbfe640ad9e1a243e4e12e5a7b0f1f876108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->