### PR TITLE
Add comprehensive logging to all scraper run() functions

### DIFF
--- a/src/scrapers/att.py
+++ b/src/scrapers/att.py
@@ -317,63 +317,84 @@ def run(session, config: dict, **kwargs) -> dict:
             - count: int - Number of stores processed
             - checkpoints_used: bool - Whether resume was used
     """
-    limit = kwargs.get('limit')
-    resume = kwargs.get('resume', False)
-    
-    reset_request_counter()
-    
     retailer_name = kwargs.get('retailer', 'att')
-    checkpoint_path = f"data/{retailer_name}/checkpoints/scrape_progress.json"
-    checkpoint_interval = config.get('checkpoint_interval', 100)
+    logging.info(f"[{retailer_name}] Starting scrape run")
     
-    stores = []
-    completed_urls = set()
-    checkpoints_used = False
-    
-    if resume:
-        checkpoint = utils.load_checkpoint(checkpoint_path)
-        if checkpoint:
-            stores = checkpoint.get('stores', [])
-            completed_urls = set(checkpoint.get('completed_urls', []))
-            logging.info(f"Resuming from checkpoint: {len(stores)} stores already collected")
-            checkpoints_used = True
-    
-    store_urls = get_store_urls_from_sitemap(session)
-    remaining_urls = [url for url in store_urls if url not in completed_urls]
-    
-    if limit:
-        total_needed = limit - len(stores)
-        if total_needed > 0:
-            remaining_urls = remaining_urls[:total_needed]
-        else:
-            remaining_urls = []
-    
-    for i, url in enumerate(remaining_urls):
-        store_obj = extract_store_details(session, url)
-        if store_obj:
-            stores.append(store_obj.to_dict())
-            completed_urls.add(url)
+    try:
+        limit = kwargs.get('limit')
+        resume = kwargs.get('resume', False)
         
-        if (i + 1) % checkpoint_interval == 0:
+        reset_request_counter()
+        
+        checkpoint_path = f"data/{retailer_name}/checkpoints/scrape_progress.json"
+        checkpoint_interval = config.get('checkpoint_interval', 100)
+        
+        stores = []
+        completed_urls = set()
+        checkpoints_used = False
+        
+        if resume:
+            checkpoint = utils.load_checkpoint(checkpoint_path)
+            if checkpoint:
+                stores = checkpoint.get('stores', [])
+                completed_urls = set(checkpoint.get('completed_urls', []))
+                logging.info(f"[{retailer_name}] Resuming from checkpoint: {len(stores)} stores already collected")
+                checkpoints_used = True
+        
+        store_urls = get_store_urls_from_sitemap(session)
+        logging.info(f"[{retailer_name}] Found {len(store_urls)} store URLs")
+        
+        if not store_urls:
+            logging.warning(f"[{retailer_name}] No store URLs found in sitemap")
+            return {'stores': [], 'count': 0, 'checkpoints_used': False}
+        
+        remaining_urls = [url for url in store_urls if url not in completed_urls]
+        
+        if limit:
+            logging.info(f"[{retailer_name}] Limited to {limit} stores")
+            total_needed = limit - len(stores)
+            if total_needed > 0:
+                remaining_urls = remaining_urls[:total_needed]
+            else:
+                remaining_urls = []
+        
+        total_to_process = len(remaining_urls)
+        for i, url in enumerate(remaining_urls, 1):
+            store_obj = extract_store_details(session, url)
+            if store_obj:
+                stores.append(store_obj.to_dict())
+                completed_urls.add(url)
+            
+            # Progress logging every 100 stores
+            if i % 100 == 0:
+                logging.info(f"[{retailer_name}] Progress: {i}/{total_to_process} ({i/total_to_process*100:.1f}%)")
+            
+            if i % checkpoint_interval == 0:
+                utils.save_checkpoint({
+                    'completed_count': len(stores),
+                    'completed_urls': list(completed_urls),
+                    'stores': stores,
+                    'last_updated': datetime.now().isoformat()
+                }, checkpoint_path)
+                logging.info(f"[{retailer_name}] Checkpoint saved: {len(stores)} stores processed")
+        
+        if stores:
             utils.save_checkpoint({
                 'completed_count': len(stores),
                 'completed_urls': list(completed_urls),
                 'stores': stores,
                 'last_updated': datetime.now().isoformat()
             }, checkpoint_path)
-            logging.info(f"Checkpoint saved: {len(stores)} stores processed")
-    
-    if stores:
-        utils.save_checkpoint({
-            'completed_count': len(stores),
-            'completed_urls': list(completed_urls),
+            logging.info(f"[{retailer_name}] Final checkpoint saved: {len(stores)} stores total")
+        
+        logging.info(f"[{retailer_name}] Completed: {len(stores)} stores successfully scraped")
+        
+        return {
             'stores': stores,
-            'last_updated': datetime.now().isoformat()
-        }, checkpoint_path)
-        logging.info(f"Final checkpoint saved: {len(stores)} stores total")
-    
-    return {
-        'stores': stores,
-        'count': len(stores),
-        'checkpoints_used': checkpoints_used
-    }
+            'count': len(stores),
+            'checkpoints_used': checkpoints_used
+        }
+        
+    except Exception as e:
+        logging.error(f"[{retailer_name}] Fatal error: {e}", exc_info=True)
+        raise

--- a/src/scrapers/bestbuy.py
+++ b/src/scrapers/bestbuy.py
@@ -713,64 +713,85 @@ def run(session, config: dict, **kwargs) -> dict:
             - count: int - Number of stores processed
             - checkpoints_used: bool - Whether resume was used
     """
-    limit = kwargs.get('limit')
-    resume = kwargs.get('resume', False)
-    
-    reset_request_counter()
-    
     retailer_name = kwargs.get('retailer', 'bestbuy')
-    checkpoint_path = f"data/{retailer_name}/checkpoints/scrape_progress.json"
-    checkpoint_interval = config.get('checkpoint_interval', 100)
+    logging.info(f"[{retailer_name}] Starting scrape run")
     
-    stores = []
-    completed_urls = set()
-    checkpoints_used = False
-    
-    if resume:
-        checkpoint = utils.load_checkpoint(checkpoint_path)
-        if checkpoint:
-            stores = checkpoint.get('stores', [])
-            completed_urls = set(checkpoint.get('completed_urls', []))
-            logging.info(f"Resuming from checkpoint: {len(stores)} stores already collected")
-            checkpoints_used = True
-    
-    store_list = get_all_store_ids(session)
-    remaining_stores = [s for s in store_list if s.get('url') not in completed_urls]
-    
-    if limit:
-        total_needed = limit - len(stores)
-        if total_needed > 0:
-            remaining_stores = remaining_stores[:total_needed]
-        else:
-            remaining_stores = []
-    
-    for i, store_info in enumerate(remaining_stores):
-        store_url = store_info.get('url')
-        store_obj = extract_store_details(session, store_url)
-        if store_obj:
-            stores.append(store_obj.to_dict())
-            completed_urls.add(store_url)
+    try:
+        limit = kwargs.get('limit')
+        resume = kwargs.get('resume', False)
         
-        if (i + 1) % checkpoint_interval == 0:
+        reset_request_counter()
+        
+        checkpoint_path = f"data/{retailer_name}/checkpoints/scrape_progress.json"
+        checkpoint_interval = config.get('checkpoint_interval', 100)
+        
+        stores = []
+        completed_urls = set()
+        checkpoints_used = False
+        
+        if resume:
+            checkpoint = utils.load_checkpoint(checkpoint_path)
+            if checkpoint:
+                stores = checkpoint.get('stores', [])
+                completed_urls = set(checkpoint.get('completed_urls', []))
+                logging.info(f"[{retailer_name}] Resuming from checkpoint: {len(stores)} stores already collected")
+                checkpoints_used = True
+        
+        store_list = get_all_store_ids(session)
+        logging.info(f"[{retailer_name}] Found {len(store_list)} store URLs")
+        
+        if not store_list:
+            logging.warning(f"[{retailer_name}] No store URLs found in sitemap")
+            return {'stores': [], 'count': 0, 'checkpoints_used': False}
+        
+        remaining_stores = [s for s in store_list if s.get('url') not in completed_urls]
+        
+        if limit:
+            logging.info(f"[{retailer_name}] Limited to {limit} stores")
+            total_needed = limit - len(stores)
+            if total_needed > 0:
+                remaining_stores = remaining_stores[:total_needed]
+            else:
+                remaining_stores = []
+        
+        total_to_process = len(remaining_stores)
+        for i, store_info in enumerate(remaining_stores, 1):
+            store_url = store_info.get('url')
+            store_obj = extract_store_details(session, store_url)
+            if store_obj:
+                stores.append(store_obj.to_dict())
+                completed_urls.add(store_url)
+            
+            # Progress logging every 100 stores
+            if i % 100 == 0:
+                logging.info(f"[{retailer_name}] Progress: {i}/{total_to_process} ({i/total_to_process*100:.1f}%)")
+            
+            if i % checkpoint_interval == 0:
+                utils.save_checkpoint({
+                    'completed_count': len(stores),
+                    'completed_urls': list(completed_urls),
+                    'stores': stores,
+                    'last_updated': datetime.now().isoformat()
+                }, checkpoint_path)
+                logging.info(f"[{retailer_name}] Checkpoint saved: {len(stores)} stores processed")
+        
+        if stores:
             utils.save_checkpoint({
                 'completed_count': len(stores),
                 'completed_urls': list(completed_urls),
                 'stores': stores,
                 'last_updated': datetime.now().isoformat()
             }, checkpoint_path)
-            logging.info(f"Checkpoint saved: {len(stores)} stores processed")
-    
-    if stores:
-        utils.save_checkpoint({
-            'completed_count': len(stores),
-            'completed_urls': list(completed_urls),
+            logging.info(f"[{retailer_name}] Final checkpoint saved: {len(stores)} stores total")
+        
+        logging.info(f"[{retailer_name}] Completed: {len(stores)} stores successfully scraped")
+        
+        return {
             'stores': stores,
-            'last_updated': datetime.now().isoformat()
-        }, checkpoint_path)
-        logging.info(f"Final checkpoint saved: {len(stores)} stores total")
-    
-    return {
-        'stores': stores,
-        'count': len(stores),
-        'checkpoints_used': checkpoints_used
-    }
+            'count': len(stores),
+            'checkpoints_used': checkpoints_used
+        }
+        
+    except Exception as e:
+        logging.error(f"[{retailer_name}] Fatal error: {e}", exc_info=True)
+        raise

--- a/src/scrapers/verizon.py
+++ b/src/scrapers/verizon.py
@@ -700,78 +700,102 @@ def run(session, config: dict, **kwargs) -> dict:
             - count: int - Number of stores processed
             - checkpoints_used: bool - Whether resume was used
     """
-    limit = kwargs.get('limit')
-    resume = kwargs.get('resume', False)
-    
-    reset_request_counter()
-    
     retailer_name = kwargs.get('retailer', 'verizon')
+    logging.info(f"[{retailer_name}] Starting scrape run")
     
-    # Auto-select delays based on proxy mode for optimal performance
-    proxy_mode = config.get('proxy', {}).get('mode', 'direct')
-    min_delay, max_delay = utils.select_delays(config, proxy_mode)
-    logging.info(f"[{retailer_name}] Using delays: {min_delay:.1f}-{max_delay:.1f}s (mode: {proxy_mode})")
-    
-    checkpoint_path = f"data/{retailer_name}/checkpoints/scrape_progress.json"
-    # Verizon uses smaller interval (10) due to slower multi-phase crawl
-    checkpoint_interval = config.get('checkpoint_interval', 10)
-    
-    stores = []
-    completed_urls = set()
-    checkpoints_used = False
-    
-    if resume:
-        checkpoint = utils.load_checkpoint(checkpoint_path)
-        if checkpoint:
-            stores = checkpoint.get('stores', [])
-            completed_urls = set(checkpoint.get('completed_urls', []))
-            logging.info(f"Resuming from checkpoint: {len(stores)} stores already collected")
-            checkpoints_used = True
-    
-    all_states = get_all_states(session)
-    
-    all_store_urls = []
-    for state in all_states:
-        cities = get_cities_for_state(session, state['url'], state['name'])
-        for city in cities:
-            store_infos = get_stores_for_city(session, city['url'], city['city'], city['state'])
-            all_store_urls.extend([s['url'] for s in store_infos])
-    
-    remaining_urls = [url for url in all_store_urls if url not in completed_urls]
-    
-    if limit:
-        total_needed = limit - len(stores)
-        if total_needed > 0:
-            remaining_urls = remaining_urls[:total_needed]
-        else:
-            remaining_urls = []
-    
-    for i, url in enumerate(remaining_urls):
-        store_data = extract_store_details(session, url)
-        if store_data:
-            stores.append(store_data)
-            completed_urls.add(url)
+    try:
+        limit = kwargs.get('limit')
+        resume = kwargs.get('resume', False)
         
-        if (i + 1) % checkpoint_interval == 0:
+        reset_request_counter()
+        
+        # Auto-select delays based on proxy mode for optimal performance
+        proxy_mode = config.get('proxy', {}).get('mode', 'direct')
+        min_delay, max_delay = utils.select_delays(config, proxy_mode)
+        logging.info(f"[{retailer_name}] Using delays: {min_delay:.1f}-{max_delay:.1f}s (mode: {proxy_mode})")
+        
+        checkpoint_path = f"data/{retailer_name}/checkpoints/scrape_progress.json"
+        # Verizon uses smaller interval (10) due to slower multi-phase crawl
+        checkpoint_interval = config.get('checkpoint_interval', 10)
+        
+        stores = []
+        completed_urls = set()
+        checkpoints_used = False
+        
+        if resume:
+            checkpoint = utils.load_checkpoint(checkpoint_path)
+            if checkpoint:
+                stores = checkpoint.get('stores', [])
+                completed_urls = set(checkpoint.get('completed_urls', []))
+                logging.info(f"[{retailer_name}] Resuming from checkpoint: {len(stores)} stores already collected")
+                checkpoints_used = True
+        
+        logging.info(f"[{retailer_name}] Phase 1: Discovering states")
+        all_states = get_all_states(session)
+        logging.info(f"[{retailer_name}] Found {len(all_states)} states")
+        
+        logging.info(f"[{retailer_name}] Phase 2-3: Discovering cities and stores")
+        all_store_urls = []
+        for state in all_states:
+            cities = get_cities_for_state(session, state['url'], state['name'])
+            for city in cities:
+                store_infos = get_stores_for_city(session, city['url'], city['city'], city['state'])
+                all_store_urls.extend([s['url'] for s in store_infos])
+        
+        logging.info(f"[{retailer_name}] Found {len(all_store_urls)} store URLs total")
+        
+        if not all_store_urls:
+            logging.warning(f"[{retailer_name}] No store URLs found")
+            return {'stores': [], 'count': 0, 'checkpoints_used': False}
+        
+        remaining_urls = [url for url in all_store_urls if url not in completed_urls]
+        
+        if limit:
+            logging.info(f"[{retailer_name}] Limited to {limit} stores")
+            total_needed = limit - len(stores)
+            if total_needed > 0:
+                remaining_urls = remaining_urls[:total_needed]
+            else:
+                remaining_urls = []
+        
+        logging.info(f"[{retailer_name}] Phase 4: Extracting store details")
+        total_to_process = len(remaining_urls)
+        for i, url in enumerate(remaining_urls, 1):
+            store_data = extract_store_details(session, url)
+            if store_data:
+                stores.append(store_data)
+                completed_urls.add(url)
+            
+            # Progress logging every 100 stores
+            if i % 100 == 0:
+                logging.info(f"[{retailer_name}] Progress: {i}/{total_to_process} ({i/total_to_process*100:.1f}%)")
+            
+            if i % checkpoint_interval == 0:
+                utils.save_checkpoint({
+                    'completed_count': len(stores),
+                    'completed_urls': list(completed_urls),
+                    'stores': stores,
+                    'last_updated': datetime.now().isoformat()
+                }, checkpoint_path)
+                logging.info(f"[{retailer_name}] Checkpoint saved: {len(stores)} stores processed")
+        
+        if stores:
             utils.save_checkpoint({
                 'completed_count': len(stores),
                 'completed_urls': list(completed_urls),
                 'stores': stores,
                 'last_updated': datetime.now().isoformat()
             }, checkpoint_path)
-            logging.info(f"Checkpoint saved: {len(stores)} stores processed")
-    
-    if stores:
-        utils.save_checkpoint({
-            'completed_count': len(stores),
-            'completed_urls': list(completed_urls),
+            logging.info(f"[{retailer_name}] Final checkpoint saved: {len(stores)} stores total")
+        
+        logging.info(f"[{retailer_name}] Completed: {len(stores)} stores successfully scraped")
+        
+        return {
             'stores': stores,
-            'last_updated': datetime.now().isoformat()
-        }, checkpoint_path)
-        logging.info(f"Final checkpoint saved: {len(stores)} stores total")
-    
-    return {
-        'stores': stores,
-        'count': len(stores),
-        'checkpoints_used': checkpoints_used
-    }
+            'count': len(stores),
+            'checkpoints_used': checkpoints_used
+        }
+        
+    except Exception as e:
+        logging.error(f"[{retailer_name}] Fatal error: {e}", exc_info=True)
+        raise

--- a/src/scrapers/walmart.py
+++ b/src/scrapers/walmart.py
@@ -299,63 +299,84 @@ def run(session, config: dict, **kwargs) -> dict:
             - count: int - Number of stores processed
             - checkpoints_used: bool - Whether resume was used
     """
-    limit = kwargs.get('limit')
-    resume = kwargs.get('resume', False)
-    
-    reset_request_counter()
-    
     retailer_name = kwargs.get('retailer', 'walmart')
-    checkpoint_path = f"data/{retailer_name}/checkpoints/scrape_progress.json"
-    checkpoint_interval = config.get('checkpoint_interval', 100)
+    logging.info(f"[{retailer_name}] Starting scrape run")
     
-    stores = []
-    completed_urls = set()
-    checkpoints_used = False
-    
-    if resume:
-        checkpoint = utils.load_checkpoint(checkpoint_path)
-        if checkpoint:
-            stores = checkpoint.get('stores', [])
-            completed_urls = set(checkpoint.get('completed_urls', []))
-            logging.info(f"Resuming from checkpoint: {len(stores)} stores already collected")
-            checkpoints_used = True
-    
-    store_urls = get_store_urls_from_sitemap(session)
-    remaining_urls = [url for url in store_urls if url not in completed_urls]
-    
-    if limit:
-        total_needed = limit - len(stores)
-        if total_needed > 0:
-            remaining_urls = remaining_urls[:total_needed]
-        else:
-            remaining_urls = []
-    
-    for i, url in enumerate(remaining_urls):
-        store_obj = extract_store_details(session, url)
-        if store_obj:
-            stores.append(store_obj.to_dict())
-            completed_urls.add(url)
+    try:
+        limit = kwargs.get('limit')
+        resume = kwargs.get('resume', False)
         
-        if (i + 1) % checkpoint_interval == 0:
+        reset_request_counter()
+        
+        checkpoint_path = f"data/{retailer_name}/checkpoints/scrape_progress.json"
+        checkpoint_interval = config.get('checkpoint_interval', 100)
+        
+        stores = []
+        completed_urls = set()
+        checkpoints_used = False
+        
+        if resume:
+            checkpoint = utils.load_checkpoint(checkpoint_path)
+            if checkpoint:
+                stores = checkpoint.get('stores', [])
+                completed_urls = set(checkpoint.get('completed_urls', []))
+                logging.info(f"[{retailer_name}] Resuming from checkpoint: {len(stores)} stores already collected")
+                checkpoints_used = True
+        
+        store_urls = get_store_urls_from_sitemap(session)
+        logging.info(f"[{retailer_name}] Found {len(store_urls)} store URLs")
+        
+        if not store_urls:
+            logging.warning(f"[{retailer_name}] No store URLs found in sitemap")
+            return {'stores': [], 'count': 0, 'checkpoints_used': False}
+        
+        remaining_urls = [url for url in store_urls if url not in completed_urls]
+        
+        if limit:
+            logging.info(f"[{retailer_name}] Limited to {limit} stores")
+            total_needed = limit - len(stores)
+            if total_needed > 0:
+                remaining_urls = remaining_urls[:total_needed]
+            else:
+                remaining_urls = []
+        
+        total_to_process = len(remaining_urls)
+        for i, url in enumerate(remaining_urls, 1):
+            store_obj = extract_store_details(session, url)
+            if store_obj:
+                stores.append(store_obj.to_dict())
+                completed_urls.add(url)
+            
+            # Progress logging every 100 stores
+            if i % 100 == 0:
+                logging.info(f"[{retailer_name}] Progress: {i}/{total_to_process} ({i/total_to_process*100:.1f}%)")
+            
+            if i % checkpoint_interval == 0:
+                utils.save_checkpoint({
+                    'completed_count': len(stores),
+                    'completed_urls': list(completed_urls),
+                    'stores': stores,
+                    'last_updated': datetime.now().isoformat()
+                }, checkpoint_path)
+                logging.info(f"[{retailer_name}] Checkpoint saved: {len(stores)} stores processed")
+        
+        if stores:
             utils.save_checkpoint({
                 'completed_count': len(stores),
                 'completed_urls': list(completed_urls),
                 'stores': stores,
                 'last_updated': datetime.now().isoformat()
             }, checkpoint_path)
-            logging.info(f"Checkpoint saved: {len(stores)} stores processed")
-    
-    if stores:
-        utils.save_checkpoint({
-            'completed_count': len(stores),
-            'completed_urls': list(completed_urls),
+            logging.info(f"[{retailer_name}] Final checkpoint saved: {len(stores)} stores total")
+        
+        logging.info(f"[{retailer_name}] Completed: {len(stores)} stores successfully scraped")
+        
+        return {
             'stores': stores,
-            'last_updated': datetime.now().isoformat()
-        }, checkpoint_path)
-        logging.info(f"Final checkpoint saved: {len(stores)} stores total")
-    
-    return {
-        'stores': stores,
-        'count': len(stores),
-        'checkpoints_used': checkpoints_used
-    }
+            'count': len(stores),
+            'checkpoints_used': checkpoints_used
+        }
+        
+    except Exception as e:
+        logging.error(f"[{retailer_name}] Fatal error: {e}", exc_info=True)
+        raise


### PR DESCRIPTION
Issue #5: Enhanced logging and error handling for all scrapers

Changes:
- Add start/completion logging with retailer name prefix
- Add discovery progress logging (URLs/IDs found)
- Add progress updates every 100 stores with percentage
- Add empty result warnings
- Add try/except wrapper with exc_info logging
- Add limit logging when --limit is used
- Standardize logging format: [{retailer}] prefix

Benefits:
- Better visibility into scraper progress
- Easier debugging with detailed logs
- Consistent logging format across all retailers
- Exception handling with full stack traces

Updated scrapers:
- walmart.py
- att.py
- target.py
- tmobile.py
- verizon.py (with 4-phase discovery logging)
- bestbuy.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves observability and resilience of scraper executions across `walmart.py`, `att.py`, `target.py`, `tmobile.py`, `verizon.py`, and `bestbuy.py`.
> 
> - **Standardized logs**: `[{retailer}]`-prefixed start, discovery counts (URLs/IDs), limit usage, periodic progress (every 100), checkpoint saves, final summary
> - **Early-empty handling**: return empty result with warning when no URLs/IDs are found
> - **Checkpointing**: periodic and final checkpoint saves with counts and timestamps
> - **Error handling**: wrap `run()` in `try/except` with `exc_info=True` fatal logging
> - **Verizon-specific**: phased logging (states → cities → stores → details) and delay selection logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1246955295883edf671f8664b750feaccdfc7b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->