### PR TITLE
fix(test): Correct proxy URL format assertions

### DIFF
--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -93,7 +93,8 @@ class TestProxyClientResidentialProxyURL:
         )
         client = ProxyClient(config)
         url = client._build_residential_proxy_url()
-        assert url == "http://customer_test:testpass@pr.oxylabs.io:7777"
+        # Oxylabs format adds customer- prefix to username
+        assert url == "http://customer-customer_test:testpass@pr.oxylabs.io:7777"
     
     def test_build_proxy_url_with_country(self):
         """Test proxy URL with country targeting"""
@@ -105,7 +106,8 @@ class TestProxyClientResidentialProxyURL:
         )
         client = ProxyClient(config)
         url = client._build_residential_proxy_url()
-        assert "country-de" in url
+        # Oxylabs uses cc-{COUNTRY} format with uppercase country code
+        assert "cc-DE" in url
     
     def test_build_proxy_url_with_city(self):
         """Test proxy URL with city targeting"""
@@ -118,7 +120,8 @@ class TestProxyClientResidentialProxyURL:
         )
         client = ProxyClient(config)
         url = client._build_residential_proxy_url()
-        assert "country-us" in url
+        # Oxylabs uses cc-{COUNTRY} and city-{city} format
+        assert "cc-US" in url
         assert "city-newyork" in url
     
     def test_build_proxy_url_with_state(self):
@@ -131,7 +134,8 @@ class TestProxyClientResidentialProxyURL:
         )
         client = ProxyClient(config)
         url = client._build_residential_proxy_url()
-        assert "state-california" in url
+        # Oxylabs uses st-{state} format for US states
+        assert "st-california" in url
     
     def test_build_proxy_url_with_sticky_session(self):
         """Test proxy URL with sticky session"""
@@ -144,7 +148,8 @@ class TestProxyClientResidentialProxyURL:
         )
         client = ProxyClient(config)
         url = client._build_residential_proxy_url()
-        assert "session-session123" in url
+        # Oxylabs uses sessid-{session_id} format for sticky sessions
+        assert "sessid-session123" in url
 
 
 class TestProxyClientGetHeaders:


### PR DESCRIPTION
## Summary

- Fix 5 failing proxy client tests that had incorrect assertions for Oxylabs URL format

## Changes

Updated test assertions in `tests/test_proxy_client.py` to match actual Oxylabs residential proxy URL format:

| Component | Old Assertion | Correct Assertion |
|-----------|--------------|-------------------|
| Username | `customer_test` | `customer-customer_test` |
| Country | `country-de` | `cc-DE` |
| State | `state-california` | `st-california` |
| Session | `session-session123` | `sessid-session123` |

The implementation was already correct per Oxylabs documentation; only the test assertions needed updating.

## Test plan

- [x] Run `pytest tests/test_proxy_client.py` - all 31 tests pass
- [x] Run full test suite - 176 passed, 2 skipped

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses only on correcting test expectations for Oxylabs residential proxy URL format.
> 
> - Updates `tests/test_proxy_client.py` assertions in proxy URL builder tests:
>   - Username includes `customer-` prefix
>   - Country targeting uses `cc-{COUNTRY}` with uppercase country code
>   - City assertion remains `city-{city}` with country check updated to `cc-{COUNTRY}`
>   - State targeting uses `st-{state}`
>   - Sticky sessions use `sessid-{session_id}`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 079d269297fd46da7e68e774a77fc6870d83a172. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->