### PR TITLE
fix: Standardize scraper delay logic using shared utilities

### DIFF
--- a/tests/test_scrapers/test_tmobile.py
+++ b/tests/test_scrapers/test_tmobile.py
@@ -16,9 +16,10 @@ from src.scrapers.tmobile import (
     run,
     get_request_count,
     reset_request_counter,
-    _check_pause_logic,
     _extract_single_store,
+    _request_counter,
 )
+from src.shared.request_counter import check_pause_logic
 from src.shared.session_factory import create_session_factory
 from src.shared.cache import URLCache, DEFAULT_CACHE_EXPIRY_DAYS as URL_CACHE_EXPIRY_DAYS
 
@@ -415,44 +416,41 @@ class TestTMobileRateLimiting:
         reset_request_counter()
         assert get_request_count() == 0
 
-    @patch('src.scrapers.tmobile.time.sleep')
-    @patch('src.scrapers.tmobile.random.uniform')
+    @patch('src.shared.request_counter.time.sleep')
+    @patch('src.shared.request_counter.random.uniform')
     def test_pause_at_50_requests(self, mock_uniform, mock_sleep):
         """Test that pause triggers at 50 request threshold."""
         mock_uniform.return_value = 15
         reset_request_counter()
 
-        from src.scrapers.tmobile import _request_counter
         _request_counter._count = 50
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='tmobile')
 
         mock_sleep.assert_called_once()
         mock_uniform.assert_called()
 
-    @patch('src.scrapers.tmobile.time.sleep')
-    @patch('src.scrapers.tmobile.random.uniform')
+    @patch('src.shared.request_counter.time.sleep')
+    @patch('src.shared.request_counter.random.uniform')
     def test_pause_at_200_requests(self, mock_uniform, mock_sleep):
         """Test that longer pause triggers at 200 request threshold."""
         mock_uniform.return_value = 180
         reset_request_counter()
 
-        from src.scrapers.tmobile import _request_counter
         _request_counter._count = 200
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='tmobile')
 
         mock_sleep.assert_called_once()
 
-    @patch('src.scrapers.tmobile.time.sleep')
+    @patch('src.shared.request_counter.time.sleep')
     def test_no_pause_between_thresholds(self, mock_sleep):
         """Test that no pause occurs between thresholds."""
         reset_request_counter()
 
-        from src.scrapers.tmobile import _request_counter
         _request_counter._count = 25
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='tmobile')
 
         mock_sleep.assert_not_called()
 

--- a/tests/test_scrapers/test_verizon.py
+++ b/tests/test_scrapers/test_verizon.py
@@ -15,10 +15,11 @@ from src.scrapers.verizon import (
     run,
     get_request_count,
     reset_request_counter,
-    _check_pause_logic,
     _fetch_cities_for_state_worker,
     _fetch_stores_for_city_worker,
+    _request_counter,
 )
+from src.shared.request_counter import check_pause_logic
 from src.shared.session_factory import create_session_factory
 from src.shared.cache import URLCache
 
@@ -336,44 +337,41 @@ class TestVerizonRateLimiting:
         reset_request_counter()
         assert get_request_count() == 0
 
-    @patch('src.scrapers.verizon.time.sleep')
-    @patch('src.scrapers.verizon.random.uniform')
+    @patch('src.shared.request_counter.time.sleep')
+    @patch('src.shared.request_counter.random.uniform')
     def test_pause_at_50_requests(self, mock_uniform, mock_sleep):
         """Test that pause triggers at 50 request threshold."""
         mock_uniform.return_value = 15
         reset_request_counter()
 
-        from src.scrapers.verizon import _request_counter
         _request_counter._count = 50
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='verizon')
 
         mock_sleep.assert_called_once()
         mock_uniform.assert_called()
 
-    @patch('src.scrapers.verizon.time.sleep')
-    @patch('src.scrapers.verizon.random.uniform')
+    @patch('src.shared.request_counter.time.sleep')
+    @patch('src.shared.request_counter.random.uniform')
     def test_pause_at_200_requests(self, mock_uniform, mock_sleep):
         """Test that longer pause triggers at 200 request threshold."""
         mock_uniform.return_value = 180
         reset_request_counter()
 
-        from src.scrapers.verizon import _request_counter
         _request_counter._count = 200
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='verizon')
 
         mock_sleep.assert_called_once()
 
-    @patch('src.scrapers.verizon.time.sleep')
+    @patch('src.shared.request_counter.time.sleep')
     def test_no_pause_between_thresholds(self, mock_sleep):
         """Test that no pause occurs between thresholds."""
         reset_request_counter()
 
-        from src.scrapers.verizon import _request_counter
         _request_counter._count = 25
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='verizon')
 
         mock_sleep.assert_not_called()
 

--- a/tests/test_scrapers/test_walmart.py
+++ b/tests/test_scrapers/test_walmart.py
@@ -14,10 +14,11 @@ from src.scrapers.walmart import (
     run,
     get_request_count,
     reset_request_counter,
-    _check_pause_logic,
     _get_cached_response,
     _cache_response,
+    _request_counter,
 )
+from src.shared.request_counter import check_pause_logic
 from src.shared.cache import URLCache
 
 
@@ -456,44 +457,41 @@ class TestWalmartRateLimiting:
         reset_request_counter()
         assert get_request_count() == 0
 
-    @patch('src.scrapers.walmart.time.sleep')
-    @patch('src.scrapers.walmart.random.uniform')
+    @patch('src.shared.request_counter.time.sleep')
+    @patch('src.shared.request_counter.random.uniform')
     def test_pause_at_50_requests(self, mock_uniform, mock_sleep):
         """Test that pause triggers at 50 request threshold."""
         mock_uniform.return_value = 15
         reset_request_counter()
 
-        from src.scrapers.walmart import _request_counter
         _request_counter._count = 50
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='walmart')
 
         mock_sleep.assert_called_once()
         mock_uniform.assert_called()
 
-    @patch('src.scrapers.walmart.time.sleep')
-    @patch('src.scrapers.walmart.random.uniform')
+    @patch('src.shared.request_counter.time.sleep')
+    @patch('src.shared.request_counter.random.uniform')
     def test_pause_at_200_requests(self, mock_uniform, mock_sleep):
         """Test that longer pause triggers at 200 request threshold."""
         mock_uniform.return_value = 180
         reset_request_counter()
 
-        from src.scrapers.walmart import _request_counter
         _request_counter._count = 200
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='walmart')
 
         mock_sleep.assert_called_once()
 
-    @patch('src.scrapers.walmart.time.sleep')
+    @patch('src.shared.request_counter.time.sleep')
     def test_no_pause_between_thresholds(self, mock_sleep):
         """Test that no pause occurs between thresholds."""
         reset_request_counter()
 
-        from src.scrapers.walmart import _request_counter
         _request_counter._count = 25
 
-        _check_pause_logic()
+        check_pause_logic(_request_counter, retailer='walmart')
 
         mock_sleep.assert_not_called()
 


### PR DESCRIPTION
## Summary
- Refactored all 6 scrapers to use shared `check_pause_logic` from `request_counter.py`
- Enhanced shared function to accept retailer name (for logging) and YAML config (for pause settings)
- Removed duplicate `_check_pause_logic` functions from all scrapers
- Net reduction of ~120 lines of duplicated code

## Changes
- **src/shared/request_counter.py**: Enhanced `check_pause_logic` with retailer and config parameters
- **src/scrapers/*.py**: Removed local `_check_pause_logic`, use shared function
- **tests/test_scrapers/*.py**: Updated to mock shared module

## Test plan
- [x] All 188 scraper tests pass
- [x] Pylint 10/10 on all modified files
- [ ] CI passes

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies rate-limiting across scrapers by using a single `check_pause_logic` in `src/shared/request_counter.py`, reducing duplication and enabling per-retailer config and logging.
> 
> - Enhanced `check_pause_logic` to accept `retailer` and optional YAML `config`; added disabled-pauses guard and prefixed logs
> - Replaced local `_check_pause_logic` in `att.py`, `bestbuy.py`, `target.py`, `tmobile.py`, `verizon.py`, `walmart.py` with shared function calls; removed redundant `random/time` imports
> - Adjusted Target functions to pass `yaml_config` through (`get_all_store_ids`, `get_store_details`, worker helpers)
> - Updated tests to import/patch `src.shared.request_counter` and reference module-level `_request_counter` where needed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5c41d147b2d6ec66ca4204f2e418d8dd0bdacdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal pause-handling logic across scraper modules into a centralized utility function for improved maintainability and consistency.
  * Updated request counter module to support configurable pause settings via optional parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->