### PR TITLE
ci: Drop Python 3.8, add Python 3.11/3.12 support

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,5 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        # Disable unknown-option-value (W0012) for Python 3.8 compatibility
-        # (too-many-positional-arguments not recognized in older pylint)
         # Use --fail-under=9.5 to allow minor issues in test code while catching major problems
-        pylint $(git ls-files '*.py') --disable=unknown-option-value --fail-under=9.5
+        pylint $(git ls-files '*.py') --fail-under=9.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

**URGENT**: This PR unblocks 15 technical debt PRs that are failing CI due to Python 3.8 incompatibility.

Python 3.8 reached EOL (Oct 2024) and `aiohttp==3.13.3` dropped support for it. The CI was configured to test Python 3.8 but the project documentation states "Requires Python 3.9-3.14".

### Changes

| Workflow | Before | After |
|----------|--------|-------|
| `pylint.yml` | 3.8, 3.9, 3.10 | 3.9, 3.10, 3.11 |
| `test.yml` | 3.8, 3.9, 3.10, 3.11 | 3.9, 3.10, 3.11, 3.12 |

### Additional Cleanup

- Removed obsolete Python 3.8 compatibility workaround in pylint config (the `--disable=unknown-option-value` flag)

### Impact

Once merged, all 15 open technical debt PRs (#211-#225) should pass CI.

## Test Plan

- [x] CI configuration is valid YAML
- [x] Python version matrix matches documented requirements
- [ ] CI runs pass on this PR
- [ ] Other PRs should pass CI after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to the GitHub Actions version matrix and a linter flag; no production/runtime code paths are modified.
> 
> **Overview**
> Updates CI Python version coverage by **dropping Python 3.8** and expanding newer-version testing: `pylint.yml` now runs on **3.9–3.11**, and `test.yml` runs on **3.9–3.12**.
> 
> Cleans up the Pylint workflow by removing the Python-3.8-specific `--disable=unknown-option-value` flag, leaving a single `pylint ... --fail-under=9.5` invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf426760f4b003a39e962c82c930f5f04d8dd471. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>bf42676</u></sup><!-- /BUGBOT_STATUS -->